### PR TITLE
Replace UserManager with None in tests

### DIFF
--- a/openstack_dashboard/test/test_data/ceilometer_data.py
+++ b/openstack_dashboard/test/test_data/ceilometer_data.py
@@ -55,9 +55,9 @@ def data(TEST):
                  'project_id': '2',
                  'enabled': True,
                  'domain_id': "2"}
-    TEST.ceilometer_users.add(users.User(users.UserManager(None),
+    TEST.ceilometer_users.add(users.User(None,
                                          ceilometer_user_dict1))
-    TEST.ceilometer_users.add(users.User(users.UserManager(None),
+    TEST.ceilometer_users.add(users.User(None,
                                          ceilometer_user_dict2))
 
     #tenants

--- a/openstack_dashboard/test/test_data/keystone_data.py
+++ b/openstack_dashboard/test/test_data/keystone_data.py
@@ -166,7 +166,7 @@ def data(TEST):
                  'project_id': '1',
                  'enabled': True,
                  'domain_id': "1"}
-    user = users.User(users.UserManager(None), user_dict)
+    user = users.User(None, user_dict)
     user_dict = {'id': "2",
                  'name': 'user_two',
                  'email': 'two@example.com',
@@ -175,7 +175,7 @@ def data(TEST):
                  'project_id': '1',
                  'enabled': True,
                  'domain_id': "1"}
-    user2 = users.User(users.UserManager(None), user_dict)
+    user2 = users.User(None, user_dict)
     user_dict = {'id': "3",
                  'name': 'user_three',
                  'email': 'three@example.com',
@@ -184,7 +184,7 @@ def data(TEST):
                  'project_id': '1',
                  'enabled': True,
                  'domain_id': "1"}
-    user3 = users.User(users.UserManager(None), user_dict)
+    user3 = users.User(None, user_dict)
     user_dict = {'id': "4",
                  'name': 'user_four',
                  'email': 'four@example.com',
@@ -193,7 +193,7 @@ def data(TEST):
                  'project_id': '2',
                  'enabled': True,
                  'domain_id': "2"}
-    user4 = users.User(users.UserManager(None), user_dict)
+    user4 = users.User(None, user_dict)
     TEST.users.add(user, user2, user3, user4)
     TEST.user = user  # Your "current" user
     TEST.user.service_catalog = SERVICE_CATALOG


### PR DESCRIPTION
This patch is a port of a recent Icehouse/Havana patch that unblocks most of the horizon tests (a problem caused by recent changes to keystoneclient, which the testing suite pulls in to run tests).

---

Revision: e4d63b495230057af9f3d454fe57d7ef4b2ba341
Author: Jamie Lennox jamielennox@redhat.com
Date: 7/22/2014 3:55:55 PM

```
Replace UserManager with None in tests

Don't access keystoneclient's UserManager in tests. This should be
considered private data of keystoneclient and is not actually used by
horizon tests.

Change-Id: I261e79b31dfc7388adb3dc63a3a5e54042f05e54
Closes-Bug: #1347236
(cherry picked from commit 821619fff324ba1bc3f697f585a0c350573f24a2)
(cherry picked from commit df782fc2b51f5e9d2e38e3e33a4ebdc0705a50b4)
```

---

Implements: rally-user-story US4145
Implements: rally-task TA3483
Not-in-upstream: false
