### PR TITLE
Overriding lbaas.py file

### DIFF
--- a/openstack_dashboard/api/lbaas.py
+++ b/openstack_dashboard/api/lbaas.py
@@ -126,8 +126,7 @@ def vip_create(request, **kwargs):
     :param protocol_port: transport layer port number for vip
     :returns: Vip object
     """
-    body = {'vip': {'address': kwargs['address'],
-                    'name': kwargs['name'],
+    body = {'vip': {'name': kwargs['name'],
                     'description': kwargs['description'],
                     'subnet_id': kwargs['subnet_id'],
                     'protocol_port': kwargs['protocol_port'],
@@ -138,6 +137,10 @@ def vip_create(request, **kwargs):
                     }}
     if kwargs.get('connection_limit'):
         body['vip']['connection_limit'] = kwargs['connection_limit']
+
+    if kwargs.get('address'):
+        body['vip']['address'] = kwargs['address']
+
     vip = neutronclient(request).create_vip(body).get('vip')
     return Vip(vip)
 


### PR DESCRIPTION
This patch is a forward-port of a patch from puppet-coe-service-patch
which had the following commit message:

---

Revision: 4ee88b7361bc378b2f2dc6828d69838d914dd18a
Author: Ernest Millan emillan@cisco.com
Date: 7/9/2014 12:36:12 PM

```
Overriding lbaas.py file and related puppet manifest update for TA2342
Change-Id: Ifddb4036de15aad50a5ace0693fe297412cc389c

"The current Horizon Load Balancer VIP input requires a user to input an IP
address for the VIP on the subnet that the Load Balancer Pool is on.  From
the CLI or API the neutron lb-vip-create takes a --subnet-id argument.  We
need an enhancement so that user does not have to manually type in an IP
from the subnet. Furthermore the neutron lp-pool has a param for subnet-id
and the VIP gets associated to a pool as an optional param, or from Horizon
you actually Add Vip under the LB Pool tab which inherently should already
know what the subnet is. This is an unnecessary hardship for clients and
prone to race conditions especially on shared networks."
```

---

Implements: rally-user-story US4145
Implements: rally-task TA3483
Not-in-upstream: true
