### PR TITLE
Manually disable IP version when creating network subnets.

### DIFF
--- a/openstack_dashboard/dashboards/project/networks/workflows.py
+++ b/openstack_dashboard/dashboards/project/networks/workflows.py
@@ -16,6 +16,8 @@
 
 
 import logging
+
+from django.conf import settings
 import netaddr
 
 from django.core.urlresolvers import reverse  # noqa
@@ -118,6 +120,14 @@ class CreateSubnetInfoAction(workflows.Action):
                       'network, in which case "Network Address" must be '
                       'specified. If you wish to create a network WITHOUT a '
                       'subnet, uncheck the "Create Subnet" checkbox.')
+
+    def __init__(self, request, context, *args, **kwargs):
+        super(CreateSubnetInfoAction, self).__init__(request, context, *args,
+                                                     **kwargs)
+        if not getattr(settings, 'OPENSTACK_NEUTRON_NETWORK',
+                       {}).get('enable_ipv6', True):
+            self.fields['ip_version'].widget = forms.HiddenInput()
+            self.fields['ip_version'].initial = 4
 
     def _check_subnet_data(self, cleaned_data, is_create=True):
         cidr = cleaned_data.get('cidr')

--- a/openstack_dashboard/local/local_settings.py.example
+++ b/openstack_dashboard/local/local_settings.py.example
@@ -161,6 +161,7 @@ OPENSTACK_NEUTRON_NETWORK = {
     'enable_firewall': False,
     'enable_quotas': True,
     'enable_vpn': False,
+    'enable_ipv6': True,
     # The profile_support option is used to detect if an external router can be
     # configured via the dashboard. When using specific plugins the
     # profile_support can be turned on if needed.


### PR DESCRIPTION
## Merged change from mainline master to allow disabling of IPv6.  Will have a corresponding config change coming in a separate commit.

In some configuration, IPv6 is not supported. This patch provides
a way to disable IPv6 by hiding the ip version drop down menu and
setting the initial value to IPv4.

Closes-bug: 1352404

Change-Id: I950a1e19d509fdf4816816dd7b0f05bd418e7147

Conflicts:
    openstack_dashboard/dashboards/project/networks/tests.py
    openstack_dashboard/dashboards/project/networks/workflows.py

Implements: rally-task TA7024
Backported-from: 2014.2.rc1
Backported-from: master
