### PR TITLE
DE544 - remove flavor access update from admin

### DIFF
--- a/openstack_dashboard/dashboards/admin/flavors/tables.py
+++ b/openstack_dashboard/dashboards/admin/flavors/tables.py
@@ -111,7 +111,5 @@ class FlavorsTable(tables.DataTable):
         name = "flavors"
         verbose_name = _("Flavors")
         table_actions = (FlavorFilterAction, CreateFlavor, DeleteFlavor)
-        row_actions = (UpdateFlavor,
-                       ModifyAccess,
-                       ViewFlavorExtras,
+        row_actions = (ViewFlavorExtras,
                        DeleteFlavor)


### PR DESCRIPTION
The semantics of flavor acces updates were confusing some users resulting in
removal of flavors from the system.  To avoid future issues, the option
to modify flavor access is getting removed from Horizon entirely.

Closes-rally-bug: DE544
